### PR TITLE
Remove superfluous parens

### DIFF
--- a/practitioner/networking.tex
+++ b/practitioner/networking.tex
@@ -91,7 +91,7 @@
   \item No states to maintain
   \item Data is sent immediately
   \item Supports multicast
-  \item Only probes are \verb+send()+ and \verb+receive+
+  \item Only probes are \verb+send+ and \verb+receive+
   \end{itemize}
 \end{frame}
 


### PR DESCRIPTION
Be consistent and spell probe names without ending ().
